### PR TITLE
Fix typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ You can use these materials for self-education as well.
 1. The course is free of charge. 
 1. Course consists of two phases: remote (online) phase and traditional (offline) lecture phase.
 1. Remote phase is free to join for anyone.
-1. Offline part will be accessible for students who have successfully finished remove phase and passed the interview.
+1. Offline part will be accessible for students who have successfully finished remote phase and passed the interview.
 1. Remote phase starts on September 9th 2019 and will finish in app. 3 months.
 
 


### PR DESCRIPTION
The word `remote` was written as `remove`. The typo had a risk of misleading readers.